### PR TITLE
shorter dungeon reset

### DIFF
--- a/source.py
+++ b/source.py
@@ -29,7 +29,8 @@ def resetthread():
   while True:
       schedule.run_pending()
       time.sleep(1)
-schedule.every().tuesday.at("3:59").do(resetDungeons)
+#schedule.every().tuesday.at("3:59").do(resetDungeons)
+schedule.every(96).hours.do(resetDungeons)
 
 @client.event
 async def on_message(message):


### PR DESCRIPTION
End-game characters need to farm gear for months to 100% the game. This change encourages farming and keeps players interested instead of blowing through content every Tuesday.